### PR TITLE
Feat/include all files on lint

### DIFF
--- a/src/test/unit/cueLint.test.ts
+++ b/src/test/unit/cueLint.test.ts
@@ -9,7 +9,7 @@ suite("handleDiagnosticMessages Tests", () => {
   test("ignore single line", () => {
     const content =
       "some instances are incomplete; use the -c flag to show errors or suppress this message";
-    const diagnostics = handleDiagnosticMessages(content);
+    const diagnostics = handleDiagnosticMessages("./examples/simple1.cue", content);
     assert.equal(diagnostics.length, 0);
   });
 
@@ -19,7 +19,7 @@ suite("handleDiagnosticMessages Tests", () => {
       "    ./examples/simple1.cue:7:3\n" +
       "    ./examples/simple1.cue:12:5";
 
-    const diagnostics = handleDiagnosticMessages(content);
+    const diagnostics = handleDiagnosticMessages("./examples/simple1.cue", content);
     assert.equal(diagnostics.length, 2);
     assert.equal(diagnostics[0].message, "expected operand, found 'EOF'");
     assert.equal(diagnostics[0].range.start.line, 6);


### PR DESCRIPTION
I had a problem in my cue files for dagger.io. I created a package with multiple files and got an error when using o reference of a other file. I have not tested it very good, but it looks like it should work. You should take a look at it, if any unwanted errors could happen. ;)

**Example:**
_File: A.cue_
```
package node

#Something: {
   any: string
}
```

_File: B.cue_
```
package node

#Build: #Something & {
   any: "Lorem ipsum"
}
```